### PR TITLE
revdeps: new option to print a (direct) dep source

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -93,11 +93,11 @@ func (g *Graph) Imports(ctx context.Context, pkg string) ([]string, error) {
 
 // Importers calls f with the import path of each package that directly depends
 // on pkg. The order of results is unspecified.
-func (g *Graph) Importers(ctx context.Context, pkg string, f func(string)) error {
+func (g *Graph) Importers(ctx context.Context, pkg string, f func(*Row, int)) error {
 	return g.Scan(ctx, "", func(row *Row) error {
-		for _, elt := range row.Directs {
+		for i, elt := range row.Directs {
 			if elt == pkg {
-				f(row.ImportPath)
+				f(row, i)
 				break
 			}
 		}
@@ -107,11 +107,11 @@ func (g *Graph) Importers(ctx context.Context, pkg string, f func(string)) error
 
 // ImportersScan calls f with the import path of each package that directly depends
 // on anything with pkg prefix. The order of results is unspecified.
-func (g *Graph) ImportersScan(ctx context.Context, pkg string, f func(string)) error {
+func (g *Graph) ImportersScan(ctx context.Context, pkg string, f func(*Row, int)) error {
 	return g.Scan(ctx, "", func(row *Row) error {
-		for _, elt := range row.Directs {
+		for i, elt := range row.Directs {
 			if strings.HasPrefix(elt, pkg) {
-				f(row.ImportPath)
+				f(row, i)
 				break
 			}
 		}

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -20,6 +20,7 @@ package graph
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/creachadair/repodeps/deps"
 	"github.com/golang/protobuf/proto"
@@ -96,6 +97,20 @@ func (g *Graph) Importers(ctx context.Context, pkg string, f func(string)) error
 	return g.Scan(ctx, "", func(row *Row) error {
 		for _, elt := range row.Directs {
 			if elt == pkg {
+				f(row.ImportPath)
+				break
+			}
+		}
+		return nil
+	})
+}
+
+// ImportersScan calls f with the import path of each package that directly depends
+// on anything with pkg prefix. The order of results is unspecified.
+func (g *Graph) ImportersScan(ctx context.Context, pkg string, f func(string)) error {
+	return g.Scan(ctx, "", func(row *Row) error {
+		for _, elt := range row.Directs {
+			if strings.HasPrefix(elt, pkg) {
 				f(row.ImportPath)
 				break
 			}


### PR DESCRIPTION
## #1 should be merged first

This includes all the changes form #1 and shall be rebased before merging, after #1 is merged. 

-----

Add a new option to revdeps, `-direct`, in 79ca466.

That is useful e.g in case of `-prefix github.com/src-d` and would allow to show a direct dependency -- origin of the reverse one.


That allows to investigate the result of the query like "Histogram of everything that depends on this org":

```
$ go run ./tools/revdeps -prefix -direct -store ../_dep-graph-go-mod-41286 github.com/src-d | grep -v " github.com/src-d/.*$" | cut -d" " -f1 | sort | uniq -c | sort -nr

      2 github.com/src-d/enry/v2
      1 github.com/src-d/go-git/plumbing
      1 github.com/src-d/datasets/PublicGitArchive/pga/pga
      1 github.com/src-d/borges
```

and get the list of all packages, depending on `github.com/src-d`

```
$ go run ./tools/revdeps -prefix -direct -store ../_dep-graph-go-mod-41286 github.com/src-d | grep -v " github.com/src-d/.*$" | sort | less

github.com/src-d/borges github.com/jfontan/requeue
github.com/src-d/datasets/PublicGitArchive/pga/pga github.com/smola/language-dataset
github.com/src-d/enry/v2 github.com/bblfsh/bblfshd/daemon
github.com/src-d/enry/v2 github.com/hhatto/gocloc
github.com/src-d/go-git/plumbing github.com/posener/goreadme-server
```